### PR TITLE
Fixing modules ( SQL Updater + .gitignore ) (#138)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ doc/doxygen/Database/*.dox
 .idea/
 .nbproject/
 .project
+
+# Modules
+modules/*

--- a/src/game/World.cpp
+++ b/src/game/World.cpp
@@ -1101,7 +1101,7 @@ void World::LoadConfigSettings(bool reload)
     #endif
     // module
     m_ModSQLUpdatesPath = sConfig.GetStringDefault("DatabaseUpdater.ModPathToUpdates", "");
-    if (!m_ModSQLUpdatesPath.size() || (*m_ModSQLUpdatesPath.rbegin() != '\\' && *m_ModSQLUpdatesPath.rbegin() != '/'))
+    if ((!m_ModSQLUpdatesPath.size() || (*m_ModSQLUpdatesPath.rbegin() != '\\' && *m_ModSQLUpdatesPath.rbegin() != '/')) && !m_ModSQLUpdatesPath.empty())
 #if PLATFORM == PLATFORM_WINDOWS
         m_ModSQLUpdatesPath += '\\';
 #else
@@ -1207,6 +1207,9 @@ void World::LoadSQLUpdates()
 
 void World::LoadModSQLUpdates()
 {
+    if (!m_configs[CONFIG_SQLUPDATER_ENABLED])
+        return;
+
     const struct
     {
         // db pointer
@@ -1230,13 +1233,18 @@ void World::LoadModSQLUpdates()
     // already applied before (from db)
     std::set<std::string> alreadyAppliedFiles;
 
+    if (m_ModSQLUpdatesPath.empty()) {
+        outstring_log(">> Skipping modules SQL updates.");
+        return;
+    }
+
     // get folders in modules/
     if (ACE_DIR* dira = ACE_OS::opendir(m_ModSQLUpdatesPath.c_str()))
     {
         while (ACE_DIRENT* directory = ACE_OS::readdir(dira))
         {
             // Skip the ".." and "." files.
-            if (ACE::isdotdir(directory->d_name) == true)
+            if (directory->d_name[0] == '.' || ACE::isdotdir(directory->d_name))
                 continue;
 
             // refresh path
@@ -1304,7 +1312,7 @@ void World::LoadModSQLUpdates()
 
                     // Change current directory to modules/mod_xxx/sql(path)
                     if (-1 == ACE_OS::chdir(pathsql.c_str()))
-                        sLog.outFatal("Can't change directory to %s: %s", pathsql.c_str(), strerror(errno));
+                        continue;  
 
                     // get files in modules/mod_xxx/sql/(path)/ directory
                     if (ACE_DIR* dir = ACE_OS::opendir(pathsql.c_str()))


### PR DESCRIPTION
* Fixing modules ( SQL Updater + .gitignore )

This will fix the issue with the module updater throwing errors if some of the sql folders were not created and fixing the problem with the dot files ( example : .gitkeep )

* Replace tabs with spaces

* Fixing empty string and .reload config problem